### PR TITLE
Revert Patch: Noise at DSD Playback start.

### DIFF
--- a/sound/usb/endpoint.c
+++ b/sound/usb/endpoint.c
@@ -638,21 +638,7 @@ static int data_ep_set_params(struct snd_usb_endpoint *ep,
 
 	ep->datainterval = fmt->datainterval;
 	ep->stride = frame_bits >> 3;
-
-	switch (pcm_format) {
-	case SNDRV_PCM_FORMAT_U8:
-		ep->silence_value = 0x80;
-		break;
-	case SNDRV_PCM_FORMAT_DSD_U8:
-	case SNDRV_PCM_FORMAT_DSD_U16_LE:
-	case SNDRV_PCM_FORMAT_DSD_U32_LE:
-	case SNDRV_PCM_FORMAT_DSD_U16_BE:
-	case SNDRV_PCM_FORMAT_DSD_U32_BE:
-		ep->silence_value = 0x69;
-		break;
-	default:
-		ep->silence_value = 0;
-	}
+	ep->silence_value = pcm_format == SNDRV_PCM_FORMAT_U8 ? 0x80 : 0;
 
 	/* assume max. frequency is 50% higher than nominal */
 	ep->freqmax = ep->freqn + (ep->freqn >> 1);


### PR DESCRIPTION
This patch reverts the patch
"ALSA: usb-audio: Eliminate noise at the start of DSD
playback". This is causing a 5sec delay at the USB
audio reconnect. This issue is also seen for video
streaming.

Test: Connect USB Head-set and play the audio.
      Disconnect and reconnect the Headset.
      Check the audio at reconnect immdiately
      playing the paused audio stream

Change-Id: I8e45d79e239aa65d3a6be7ada2b11bbc09271a87
Signed-off-by: Karan B <karanx.bhagoji@intel.com>
Tracked-On: https://jira01.devtools.intel.com/browse/OAM-63318