### PR TITLE
Enabling USB ROLE SWITCH QUIRK for INTEL_SUNRISEPOINT_LP_XHCI

### DIFF
--- a/drivers/usb/host/xhci-pci.c
+++ b/drivers/usb/host/xhci-pci.c
@@ -201,7 +201,8 @@ static void xhci_pci_quirks(struct device *dev, struct xhci_hcd *xhci)
 		xhci->quirks |= XHCI_MISSING_CAS;
 	if (pdev->vendor == PCI_VENDOR_ID_INTEL &&
 	    (pdev->device == PCI_DEVICE_ID_INTEL_CHERRYVIEW_XHCI ||
-	     pdev->device == PCI_DEVICE_ID_INTEL_APL_XHCI) &&
+	     pdev->device == PCI_DEVICE_ID_INTEL_APL_XHCI ||
+	     pdev->device == PCI_DEVICE_ID_INTEL_SUNRISEPOINT_LP_XHCI) &&
 	    xhci_pci_board_has_udc())
 		xhci->quirks |= XHCI_INTEL_USB_ROLE_SW;
 

--- a/drivers/usb/roles/intel-xhci-usb-role-switch.c
+++ b/drivers/usb/roles/intel-xhci-usb-role-switch.c
@@ -175,6 +175,10 @@ static int intel_xhci_usb_probe(struct platform_device *pdev)
 	if (IS_ERR(data->role_sw))
 		return PTR_ERR(data->role_sw);
 
+	intel_xhci_usb_set_role(dev, USB_ROLE_HOST);
+	msleep(10);
+	intel_xhci_usb_set_role(dev, USB_ROLE_DEVICE);
+
 	pm_runtime_set_active(dev);
 	pm_runtime_enable(dev);
 


### PR DESCRIPTION
Tracked-On:None
Signed-off-by: M Balaji <m.balaji@intel.com>
Signed-off-by: saranya <saranya.gopal@intel.com>