### PR TITLE
[Don't merge]Workaround: Don't request fw i915/kbl_dmc_ver1_04.bin

### DIFF
--- a/drivers/gpu/drm/i915/i915_irq.c
+++ b/drivers/gpu/drm/i915/i915_irq.c
@@ -2891,10 +2891,6 @@ gen8_de_irq_handler(struct drm_i915_private *dev_priv, u32 master_ctl)
 		else
 			fault_errors &= GEN8_DE_PIPE_IRQ_FAULT_ERRORS;
 
-		if (fault_errors)
-			DRM_ERROR("Fault errors on pipe %c: 0x%08x\n",
-				  pipe_name(pipe),
-				  fault_errors);
 	}
 
 	if (HAS_PCH_SPLIT(dev_priv) && !HAS_PCH_NOP(dev_priv) &&

--- a/drivers/gpu/drm/i915/intel_csr.c
+++ b/drivers/gpu/drm/i915/intel_csr.c
@@ -415,7 +415,6 @@ static void csr_load_work_fn(struct work_struct *work)
 	dev_priv = container_of(work, typeof(*dev_priv), csr.work);
 	csr = &dev_priv->csr;
 
-	request_firmware(&fw, dev_priv->csr.fw_path, &dev_priv->drm.pdev->dev);
 	if (fw)
 		dev_priv->csr.dmc_payload = parse_csr_fw(dev_priv, fw);
 


### PR DESCRIPTION
Request i915/kbl_dmc_ver1_04.bin in early boot alawys fail. It thus fall
back to syfs loading which in turn depends on uventd. Our restore
process doesn't run ueventd. So the loading function() is stuck there
for 50+ seconds.

Unfortuneally, the loading function will hold a semphore which is needed
by SNAPSHOT_FREEZE.

Our ugly hack here don't request such firmware. The only drawback so far
is that adb is offline after restore. The benefit is that we eliminate
the 50s+ sucks :)

Signed-off-by: Chen, Hu <hu1.chen@intel.com>